### PR TITLE
Mostly refined provisioning progress bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Before starting the app, take note of the currently customizable environment var
 | `DCIM_PORTAL_DATABASE_HOST` | The MySQL hostname to use.  Specify `localhost` if you want to connect to the socket `/var/run/mysqld/mysqld.sock`.
 | `DCIM_PORTAL_REDIS_HOST` | The Redis hostname to use
 | `FOREMAN_URL` | The Foreman URL to which Apipie will connect for Foreman API service
-| `FOREMAN_USERNAME` | The Foreman admin username
+| `FOREMAN_USERNAME` | The Foreman admin username.  Defaults to "admin"
 | `FOREMAN_PASSWORD` | The Foreman admin password
 
 In a separate session or service, up Sidekiq, the background jobs manager:

--- a/app/assets/stylesheets/ilo_scan_jobs.scss
+++ b/app/assets/stylesheets/ilo_scan_jobs.scss
@@ -179,21 +179,22 @@ table, .table {
 td .col-sm-12 {
   padding: 0;
 }
-.progress.active .progress-bar {
-  -webkit-transition: none !important;
-  transition: none !important;
-}
 .progress {
   height: 12px;
   width: 150px;
   border-radius: 1px;
   background-color: #bbb;
   margin-bottom: 2px;
+  overflow: visible !important;
   display: none;
 }
 .progress-bar {
   background-color: #217dbb;
   padding: 2px;
+  overflow: visible !important;
+  -webkit-transition: none !important;
+  -o-transition: none !important;
+  transition: none !important;
 }
 .progress .progress-bar {
   font-size: 11px;


### PR DESCRIPTION
`README.md`:

- MOD: Show default for $ENV['FOREMAN_USERNAME']

`app/assets/javascripts/channels/status.coffee`:

- NEW: Rewrote code to process received progress bar updates
- XXX: 3-second edge case for "Server Discovered into Backend"

`app/assets/javascripts/ilo_scan_jobs.coffee`:

- NEW: Progress bars kept in global provider
- NEW: Added indeterminate initial progress bar state
- FIX: Progress bars added when DataTables cells get added
- XXX: Hard-coded translation of "Task Completed: Discover" to
       "Server Discovered Into Backend"

`app/assets/stylesheets/ilo_scan_jobs.scss`:

- NEW: Support for indeterminate progress bars
- FIX: Overflow not showing when jQuery animating progress bar

`app/jobs/provision_job.rb`:

- MOD: Changed Rubyipmi driver from "freeipmi" to "ipmitool"
- MOD: Removed special provision status "Server Discovered Into Backend"